### PR TITLE
added missing dependencies for -auth modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <ldpath.version>3.3.0</ldpath.version>
     <jboss.logging.version>3.1.3.GA</jboss.logging.version>
     <jboss.marshalling.version>1.4.10.Final</jboss.marshalling.version>
+    <jboss.security.version>2.0.9.Final</jboss.security.version>
     <jcr.version>2.0</jcr.version>
     <jta.feature.version>1.1.1</jta.feature.version>
     <osgi-resource-locator.version>1.0.1</osgi-resource-locator.version>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -60,6 +60,7 @@
     <bundle>mvn:org.fcrepo/fcrepo-kernel-api/${project.version}</bundle>
   </feature>
 
+
   <feature name="fcrepo-kernel-modeshape" version="${project.version}" description="Fedora Repository Kernel Module" resolver="(obr)" start-level="50">
     <details>Provides modeshape-based kernel functionality for the Fedora Commons repository framework.</details>
 
@@ -163,7 +164,8 @@
 
     <bundle>mvn:org.fcrepo/fcrepo-http-commons/${project.version}</bundle>
   </feature>
-  
+
+
   <feature name="fcrepo-http-api" version="${project.version}" description="Fedora Repository HTTP API Module" resolver="(obr)" start-level="50">
     <details>Provides HTTP API functionality for the Fedora Commons repository framework.</details>
 
@@ -178,7 +180,6 @@
 
     <bundle>mvn:org.fcrepo/fcrepo-http-api/${project.version}</bundle>
   </feature>
-
 
 
   <feature name="fcrepo-auth-common" version="${project.version}" description="Fedora Repository Common Authentication Module" resolver="(obr)" start-level="50">
@@ -241,14 +242,16 @@
   </feature>
 
 
-
   <feature name="fcrepo-auth-xacml" version="${project.version}" description="Fedora Repository XACML Authentication Module" resolver="(obr)" start-level="50">
     <details>Provides XACML Authentication functionality for the Fedora Commons repository framework.</details>
-    <!-- TODO -->
 
     <feature version="${project.version}">fcrepo-kernel-api</feature>
     <feature version="${project.version}">fcrepo-kernel-modeshape</feature>
     <feature version="${project.version}">fcrepo-auth-common</feature>
+    <feature version="${project.version}">fcrepo-http-commons</feature>
+
+    <bundle dependency="true">wrap:mvn:org.jboss.security/jboss-xacml/${jboss.security.version}</bundle>
+    <bundle dependency="true">wrap:mvn:org.jboss.security/jboss-sunxacml/${jboss.security.version}</bundle>
 
     <bundle>mvn:org.fcrepo/fcrepo-auth-roles-common/${project.version}</bundle>
     <bundle>mvn:org.fcrepo/fcrepo-module-auth-xacml/${project.version}</bundle>
@@ -257,11 +260,11 @@
 
   <feature name="fcrepo-auth-rbacl" version="${project.version}" description="Fedora Repository Role Based Authentication Module" resolver="(obr)" start-level="50">
     <details>Provides Role Based Authentication functionality for the Fedora Commons repository framework.</details>
-    <!-- TODO -->
 
     <feature version="${project.version}">fcrepo-kernel-api</feature>
     <feature version="${project.version}">fcrepo-kernel-modeshape</feature>
     <feature version="${project.version}">fcrepo-auth-common</feature>
+    <feature version="${project.version}">fcrepo-http-commons</feature>
 
     <bundle>mvn:org.fcrepo/fcrepo-auth-roles-common/${project.version}</bundle>
     <bundle>mvn:org.fcrepo/fcrepo-auth-roles-basic/${project.version}</bundle>
@@ -270,7 +273,6 @@
 
   <feature name="fcrepo-audit" version="${project.version}" description="Fedora Repository Audit Module" resolver="(obr)" start-level="50">
     <details>Provides Audit functionality for the Fedora Commons repository framework.</details>
-    <!-- TODO -->
 
     <feature version="${project.version}">fcrepo-kernel-api</feature>
     <feature version="${project.version}">fcrepo-kernel-modeshape</feature>


### PR DESCRIPTION
Add org.jboss.security dependencies to fcrepo-auth-xacml
Remove TODO annotations (these are now done)
Fix any inconsistent formatting of the file
